### PR TITLE
v0.9.20 - Submission Collections

### DIFF
--- a/Waymark.php
+++ b/Waymark.php
@@ -4,7 +4,7 @@
 Plugin Name: Waymark
 Plugin URI: https://www.waymark.dev/
 Description: Mapping with WordPress made easy. With Waymark enabled, click on the "Maps" link in the sidebar to create and edit Maps. Once you are happy with your Map, copy the Waymark shortcode and add it to your content.
-Version: 0.9.19
+Version: 0.9.20
 Text Domain: waymark
 Author: Joe Hawes
 Author URI: https://www.morehawes.co.uk/

--- a/inc/Admin/Waymark_Settings.php
+++ b/inc/Admin/Waymark_Settings.php
@@ -514,6 +514,18 @@ class Waymark_Settings {
 		
 		// ==================== Submission ====================
 		
+		//Build list of Collections to use as <select> options
+		$collection_objects = get_terms([
+			'taxonomy' => 'waymark_collection',
+			'hide_empty' => false
+		]);
+		$collection_array = [
+			'' => ' - '
+		];
+		foreach($collection_objects as $collection) {
+			$collection_array[$collection->term_id] = $collection->name;
+		}
+			
 		//Roles
 		if(! function_exists('get_editable_roles')) {
     	require_once ABSPATH . 'wp-admin/includes/user.php';
@@ -586,7 +598,7 @@ class Waymark_Settings {
 							'name' => 'submission_status',
 							'id' => 'submission_users_status',
 							'type' => 'select',
-							'title' => esc_html__('Post Status', 'waymark'),
+							'title' => esc_html__('Default Status', 'waymark'),
 							'default' => Waymark_Config::get_setting('submission', 'from_users', 'submission_status'),
 							'tip' => esc_attr__('This is the initial status of the submitted Map. Note! Publish means that the Map (including any images added) will be *immediately* visible on your site.', 'waymark'),
 							'options' => array(
@@ -594,15 +606,23 @@ class Waymark_Settings {
 								'draft' => esc_attr__('Draft', 'waymark')
 							)							
 						),
-						'submission_alert' => array(
-							'name' => 'submission_alert',
-							'id' => 'submission_users_alert',
-							'type' => 'boolean',
-							'title' => esc_html__('Email Alert', 'waymark'),
-							'default' => Waymark_Config::get_setting('submission', 'from_users', 'submission_alert'),
-							'tip' => esc_attr__('Receive email alerts for new submissions.', 'waymark'),
-							'class' => 'waymark-hidden'
-						),																																								
+						'submission_collection' => array(
+							'name' => 'submission_collection',
+							'id' => 'submission_users_collection',
+							'type' => 'select',
+							'title' => esc_html__('Default Collection', 'waymark'),
+							'tip' => esc_attr__('If specified, user submissions will be automatically added to this Collection.', 'waymark'),
+							'options' => $collection_array
+						),
+// 						'submission_alert' => array(
+// 							'name' => 'submission_alert',
+// 							'id' => 'submission_users_alert',
+// 							'type' => 'boolean',
+// 							'title' => esc_html__('Email Alert', 'waymark'),
+// 							'default' => Waymark_Config::get_setting('submission', 'from_users', 'submission_alert'),
+// 							'tip' => esc_attr__('Receive email alerts for new submissions.', 'waymark'),
+// 							'class' => 'waymark-hidden'
+// 						)																																																			
 					)											
 				),
 				
@@ -652,7 +672,7 @@ class Waymark_Settings {
 							'name' => 'submission_status',
 							'id' => 'submission_public_status',
 							'type' => 'select',
-							'title' => esc_html__('Post Status', 'waymark'),
+							'title' => esc_html__('Default Status', 'waymark'),
 							'default' => Waymark_Config::get_setting('submission', 'from_public', 'submission_status'),
 							'tip' => esc_attr__('This is the initial status of the submitted Map. Note! Publish means that the Map (including any images added) will be *immediately* visible on your site.', 'waymark'),
 							'options' => array(
@@ -661,15 +681,23 @@ class Waymark_Settings {
 							),
 							'class' => ''					
 						),
-						'submission_alert' => array(
-							'name' => 'submission_alert',
-							'id' => 'submission_public_alert',
-							'type' => 'boolean',
-							'title' => esc_html__('Email Alert', 'waymark'),
-							'default' => Waymark_Config::get_setting('submission', 'from_public', 'submission_alert'),
-							'tip' => esc_attr__('Receive email alerts for new submissions.', 'waymark'),
-							'class' => 'waymark-hidden'
-						),																																							
+						'submission_collection' => array(
+							'name' => 'submission_collection',
+							'id' => 'submission_public_collection',
+							'type' => 'select',
+							'title' => esc_html__('Default Collection', 'waymark'),
+							'tip' => esc_attr__('If specified, user submissions will be automatically added to this Collection.', 'waymark'),
+							'options' => $collection_array
+						),
+// 						'submission_alert' => array(
+// 							'name' => 'submission_alert',
+// 							'id' => 'submission_public_alert',
+// 							'type' => 'boolean',
+// 							'title' => esc_html__('Email Alert', 'waymark'),
+// 							'default' => Waymark_Config::get_setting('submission', 'from_public', 'submission_alert'),
+// 							'tip' => esc_attr__('Receive email alerts for new submissions.', 'waymark'),
+// 							'class' => 'waymark-hidden'
+// 						),																																							
 					)											
 				)				
 			)

--- a/inc/Waymark_Config.php
+++ b/inc/Waymark_Config.php
@@ -11,7 +11,7 @@ class Waymark_Config {
 			'plugin_name' => 'Waymark',
 			'plugin_name_short' => 'Waymark',		
 			'custom_types' => array(),
-			'plugin_version' => '0.9.19',
+			'plugin_version' => '0.9.20',
 			'nonce_string' => 'Waymark_Nonce',
 			'site_url' => 'https://www.waymark.dev/',
 			'directory_url' => 'https://wordpress.org/support/plugin/waymark/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Waymark",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Waymark",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "Waymark for WordPress",
   "author": "Joe Hawes",
   "main": "Gruntfile.js",

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.6  
 **Tested up to:** 6.0  
 **Requires PHP:** 5.2  
-**Stable tag:** 0.9.19  
+**Stable tag:** 0.9.20  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -110,6 +110,10 @@ A big thank you to the following projects and their contributors. Without their 
 
 
 ## Changelog ##
+
+### 0.9.20 ###
+
+* Front-end <a href="https://www.waymark.dev/docs/submissions/">Submissions</a> can now be added to a <a href="https://www.waymark.dev/docs/collections/">Collection</a> by default. A collection for User and Guest submissions can be specified in Settings > Submissions > Default Collection.
 
 ### 0.9.19 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Create interactive Maps, Add custom Markers, Display geotagged photos, ele
 Requires at least: 4.6
 Tested up to: 6.0
 Requires PHP: 5.2
-Stable tag: 0.9.19
+Stable tag: 0.9.20
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -96,6 +96,10 @@ A big thank you to the following projects and their contributors. Without their 
 9. Waymark was designed to be very flexible, with lots of Settings to choose from.
 
 == Changelog ==
+
+= 0.9.20 = 
+
+* Front-end <a href="https://www.waymark.dev/docs/submissions/">Submissions</a> can now be added to a <a href="https://www.waymark.dev/docs/collections/">Collection</a> by default. A collection for User and Guest submissions can be specified in Settings > Submissions > Default Collection.
 
 = 0.9.19 = 
 


### PR DESCRIPTION
Front-end <a href="https://www.waymark.dev/docs/submissions/">Submissions</a> can now be added to a <a href="https://www.waymark.dev/docs/collections/">Collection</a> by default. A collection for User and Guest submissions can be specified in Settings > Submissions > Default Collection.